### PR TITLE
Protect Main From PID Tuning Branch Merges

### DIFF
--- a/.github/workflows/notTuning.yml
+++ b/.github/workflows/notTuning.yml
@@ -1,9 +1,11 @@
-name: Prevent PID Tuning
+name: Prevent PID Tuning on Main
 
 on:
   pull_request:
     types:
         - opened
+    branches:
+        - main
 
 jobs:
   checkTuning:


### PR DESCRIPTION
There really is no point in merging this branch into main, so this just automates rejecting PID tuning code as refered to in #37 . If we ever have more branches that we want to keep from main, we can modify this code further to avoid wasting time.